### PR TITLE
MA-03 hold and unhold transactions and balance calculation

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
@@ -3775,4 +3775,13 @@ public class CommandWrapperBuilder {
         return this;
     }
 
+    public CommandWrapperBuilder sanitizeRunningBalances(final Long accountId) {
+        this.actionName = "SANITIZE_RUNNING_BALANCE";
+        this.entityName = "SAVINGSACCOUNT";
+        this.savingsId = accountId;
+        this.entityId = null;
+        this.href = "/savingsaccounts/" + accountId + "?command=sanitizeRunningBalances";
+        return this;
+    }
+
 }

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
@@ -66,6 +66,7 @@ public class SavingsApiConstants {
     public static final String COMMAND_BLOCK_DEBIT = "blockDebit";
     public static final String COMMAND_UNBLOCK_DEBIT = "unblockDebit";
     public static final String COMMAND_UNBLOCK_CREDIT = "unblockCredit";
+    public static final String COMMAND_SANITIZE_RUNNING_BALANCES = "sanitizeRunningBalances";
 
     // general
     public static final String localeParamName = "locale";

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountSummaryData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountSummaryData.java
@@ -37,7 +37,7 @@ import org.apache.fineract.portfolio.savings.domain.interest.PostingPeriod;
  */
 @Getter
 public class SavingsAccountSummaryData implements Serializable {
-
+    private String accountNo;
     private final CurrencyData currency;
     private BigDecimal totalDeposits;
     private BigDecimal totalWithdrawals;
@@ -272,4 +272,12 @@ public class SavingsAccountSummaryData implements Serializable {
         this.interestPostedTillDate = date;
     }
 
+
+    public String getAccountNo() {
+        return accountNo;
+    }
+
+    public void setAccountNo(String accountNo) {
+        this.accountNo = accountNo;
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResource.java
@@ -607,6 +607,9 @@ public class SavingsAccountsApiResource {
         } else if (is(commandParam, SavingsApiConstants.COMMAND_UNBLOCK_ACCOUNT)) {
             final CommandWrapper commandRequest = builder.unblockSavingsAccount(accountId).build();
             result = commandsSourceWritePlatformService.logCommandSource(commandRequest);
+        } else if (is(commandParam, SavingsApiConstants.COMMAND_SANITIZE_RUNNING_BALANCES)) {
+            final CommandWrapper commandRequest = builder.sanitizeRunningBalances(accountId).build();
+            result = commandsSourceWritePlatformService.logCommandSource(commandRequest);
         }
 
         if (result == null) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResource.java
@@ -494,7 +494,7 @@ public class SavingsAccountsApiResource {
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
     @Operation(summary = "Retrieve a savings account balance application/account", description = "Retrieves a savings account balance application/account\n\n"
-            + "Example Requests :\n" + "\n" + "accountBalance/1")
+            + "Example Requests :\n" + "\n" + "balance/1")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SavingsAccountsApiResourceSwagger.GetSavingsAccountsAccountIdResponse.class)))})
     public String retrieveAccountBalance(@PathParam("accountId") @Parameter(description = "accountId") final Long accountId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
@@ -409,7 +409,7 @@ public class SavingsAccountAssembler {
         return loadTransactionsToSavingsAccountWithLimitedTransactions(account, backdatedTxnsAllowedTill, transactionDate);
     }
 
-    public SavingsAccount loadTransactionsToSavingsAccountWithLimitedTransactions(final SavingsAccount account,
+    private SavingsAccount loadTransactionsToSavingsAccountWithLimitedTransactions(final SavingsAccount account,
                                                                                   final boolean backdatedTxnsAllowedTill, LocalDate transactionDate) {
         List<SavingsAccountTransaction> savingsAccountTransactions = null;
         if (backdatedTxnsAllowedTill) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/handler/SanitizeRunningBalanceCommandHander.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/handler/SanitizeRunningBalanceCommandHander.java
@@ -1,0 +1,29 @@
+package org.apache.fineract.portfolio.savings.handler;
+
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.handler.NewCommandSourceHandler;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@CommandType(entity = "SAVINGSACCOUNT", action = "SANITIZE_RUNNING_BALANCE")
+public class SanitizeRunningBalanceCommandHander implements NewCommandSourceHandler {
+
+    private final SavingsAccountWritePlatformService writePlatformService;
+
+    @Autowired
+    public SanitizeRunningBalanceCommandHander(final SavingsAccountWritePlatformService savingAccountWritePlatformService) {
+        this.writePlatformService = savingAccountWritePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(JsonCommand command) {
+        return this.writePlatformService.satizeRunningBalances(command.getSavingsId());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/handler/SanitizeRunningBalanceCommandHander.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/handler/SanitizeRunningBalanceCommandHander.java
@@ -24,6 +24,6 @@ public class SanitizeRunningBalanceCommandHander implements NewCommandSourceHand
     @Transactional
     @Override
     public CommandProcessingResult processCommand(JsonCommand command) {
-        return this.writePlatformService.satizeRunningBalances(command.getSavingsId());
+        return this.writePlatformService.sanitizeRunningBalances(command.getSavingsId());
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountReadPlatformServiceImpl.java
@@ -174,7 +174,7 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
         final StringBuilder sqlBuilder = new StringBuilder("select " + this.savingAccountMapper.schema());
         sqlBuilder.append(" where sa.client_id = ? and sa.status_enum = 300 and sa.deposit_type_enum = ? and sa.currency_code = ? ");
 
-        final Object[] queryParameters = new Object[] { clientId, depositAccountType.getValue(), currencyCode };
+        final Object[] queryParameters = new Object[]{clientId, depositAccountType.getValue(), currencyCode};
         return this.jdbcTemplate.query(sqlBuilder.toString(), this.savingAccountMapper, queryParameters);
     }
 
@@ -1023,7 +1023,7 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
         AccountBalanceMapper() {
             final StringBuilder sqlBuilder = new StringBuilder(400);
             sqlBuilder.append(
-                    "sa.currency_code as currencyCode, sa.currency_digits as currencyDigits, sa.currency_multiplesof as inMultiplesOf, ");
+                    "sa.account_no as accountNo, sa.currency_code as currencyCode, sa.currency_digits as currencyDigits, sa.currency_multiplesof as inMultiplesOf, ");
             sqlBuilder.append("curr.name as currencyName, curr.internationalized_name_code as currencyNameCode, ");
             sqlBuilder.append("curr.display_symbol as currencyDisplaySymbol, ");
 
@@ -1072,7 +1072,7 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
 
         @Override
         public SavingsAccountSummaryData mapRow(final ResultSet rs, @SuppressWarnings("unused") final int rowNum) throws SQLException {
-
+            final String accountNo = rs.getString("accountNo");
             final String currencyCode = rs.getString("currencyCode");
             final String currencyName = rs.getString("currencyName");
             final String currencyNameCode = rs.getString("currencyNameCode");
@@ -1117,10 +1117,12 @@ public class SavingsAccountReadPlatformServiceImpl implements SavingsAccountRead
                 lastInterestCalculationDate = JdbcSupport.getLocalDate(rs, "lastInterestCalculationDate");
             }
 
-           return new SavingsAccountSummaryData(currency, totalDeposits, totalWithdrawals,
+            SavingsAccountSummaryData savingsAccountSummaryData = new SavingsAccountSummaryData(currency, totalDeposits, totalWithdrawals,
                     totalWithdrawalFees, totalAnnualFees, totalInterestEarned, totalInterestPosted, accountBalance, totalFeeCharge,
                     totalPenaltyCharge, totalOverdraftInterestDerived, totalWithholdTax, interestNotPosted, lastInterestCalculationDate,
                     availableBalance, interestPostedTillDate);
+            savingsAccountSummaryData.setAccountNo(accountNo);
+            return savingsAccountSummaryData;
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -1975,8 +1975,8 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
 
         final AppUser submittedBy = this.context.authenticatedUser();
         final boolean backdatedTxnsAllowedTill = this.savingAccountAssembler.getPivotConfigStatus();
-        final SavingsAccount account = this.savingAccountAssembler.assembleFrom(savingsId, backdatedTxnsAllowedTill);
         final LocalDate transactionDate = command.localDateValueOfParameterNamed(transactionDateParamName);
+        final SavingsAccount account = this.savingAccountAssembler.assembleWithLimitedTransacations(savingsId, backdatedTxnsAllowedTill, transactionDate);
         final boolean lienAllowed = command.booleanPrimitiveValueOfParameterNamed(lienAllowedParamName);
 
         checkClientOrGroupActive(account);
@@ -2028,7 +2028,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                 .validateReleaseAmountAndAssembleForm(holdTransaction);
 
         final boolean backdatedTxnsAllowedTill = this.savingAccountAssembler.getPivotConfigStatus();
-        final SavingsAccount account = this.savingAccountAssembler.assembleFrom(savingsId, backdatedTxnsAllowedTill);
+        final SavingsAccount account = this.savingAccountAssembler.assembleWithLimitedTransacations(savingsId, backdatedTxnsAllowedTill, transaction.getDateOf());
         checkClientOrGroupActive(account);
 
         Money runningBalance = Money.of(account.getCurrency(), account.getAccountBalance());

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -2138,7 +2138,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
 
     @Transactional
     @Override
-    public CommandProcessingResult satizeRunningBalances(final Long savingsId) {
+    public CommandProcessingResult sanitizeRunningBalances(final Long savingsId) {
         this.context.authenticatedUser();
 
         final SavingsAccount account = this.savingAccountAssembler.assembleFrom(savingsId, false);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -2136,6 +2136,23 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                 .withClientId(account.clientId()).withGroupId(account.groupId()).withSavingsId(savingsId).with(changes).build();
     }
 
+    @Transactional
+    @Override
+    public CommandProcessingResult satizeRunningBalances(final Long savingsId) {
+        this.context.authenticatedUser();
+
+        final SavingsAccount account = this.savingAccountAssembler.assembleFrom(savingsId, false);
+        checkClientOrGroupActive(account);
+
+        account.updateReason("RUNNING_BALANCE_SANITISATION");
+
+        this.savingsAccountDomainService.handleBalanceSanitisation(account);
+
+        return new CommandProcessingResultBuilder().withEntityId(savingsId).withOfficeId(account.officeId())
+                .withClientId(account.clientId()).withGroupId(account.groupId()).withSavingsId(savingsId).build();
+    }
+
+
     private void validateTransactionsForTransfer(final SavingsAccount savingsAccount, final LocalDate transferDate) {
         for (SavingsAccountTransaction transaction : savingsAccount.getTransactions()) {
             if ((DateUtils.isEqual(transferDate, transaction.getTransactionDate())

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0151_add_sanitize_balance_permission.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0151_add_sanitize_balance_permission.xml
@@ -1,0 +1,15 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="fineract" id="1">
+        <insert tableName="m_permission">
+            <column name="grouping" value="transaction_savings"/>
+            <column name="code" value="SANITIZE_RUNNING_BALANCE"/>
+            <column name="entity_name" value="SAVINGSACCOUNT"/>
+            <column name="action_name" value="SANITIZEBALANCES"/>
+            <column name="can_maker_checker" valueBoolean="true"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
@@ -689,6 +689,14 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
         }
     }
 
+    public void sanitizeRunningBalances(final LocalDate interestPostingUpToDate, final boolean postReversals) {
+
+        recalculateDailyBalances(Money.zero(this.currency), interestPostingUpToDate, false, postReversals);
+
+        this.summary.recalculateAllSummaries(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+
+    }
+
     protected List<SavingsAccountTransaction> findWithHoldTransactions() {
         final List<SavingsAccountTransaction> withholdTransactions = new ArrayList<>();
         List<SavingsAccountTransaction> trans = getTransactions();

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountSummary.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountSummary.java
@@ -182,29 +182,7 @@ public final class SavingsAccountSummary {
                 default:
                 break;
             }
-        } else {
-         // INTEREST_POSTING
-         Money interestTotal = Money.zero(currency);
-         Money withHoldTaxTotal = Money.zero(currency);
-         Money overdraftInterestTotal = Money.zero(currency);
-         this.totalDeposits = wrapper.calculateTotalDeposits(currency, savingsAccountTransactions);
-         this.totalWithdrawals = wrapper.calculateTotalWithdrawals(currency, savingsAccountTransactions);
-
-         final HashMap<String, Money> map = updateRunningBalanceAndPivotDate(true, savingsAccountTransactions,
-         interestTotal,
-         overdraftInterestTotal, withHoldTaxTotal, currency);
-         interestTotal = map.get("interestTotal");
-         withHoldTaxTotal = map.get("withHoldTax");
-         overdraftInterestTotal = map.get("overdraftInterestTotal");
-         this.totalInterestPosted = interestTotal.getAmountDefaultedToNullIfZero();
-         this.totalOverdraftInterestDerived = overdraftInterestTotal.getAmountDefaultedToNullIfZero();
-         this.totalWithholdTax = withHoldTaxTotal.getAmountDefaultedToNullIfZero();
-
-         this.accountBalance = getRunningBalanceOnPivotDate();
-         this.accountBalance = Money.of(currency, this.accountBalance).plus(Money.of(currency, this.totalDeposits))
-         .plus(this.totalInterestPosted).minus(this.totalWithdrawals).minus(this.totalWithholdTax)
-         .minus(this.totalOverdraftInterestDerived).getAmount();
-         }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountSummary.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountSummary.java
@@ -185,6 +185,29 @@ public final class SavingsAccountSummary {
         }
     }
 
+    public void recalculateAllSummaries(final MonetaryCurrency currency, final SavingsAccountTransactionSummaryWrapper wrapper, final List<SavingsAccountTransaction> savingsAccountTransactions) {
+        Money interestTotal = Money.zero(currency);
+        Money withHoldTaxTotal = Money.zero(currency);
+        Money overdraftInterestTotal = Money.zero(currency);
+        this.totalDeposits = wrapper.calculateTotalDeposits(currency, savingsAccountTransactions);
+        this.totalWithdrawals = wrapper.calculateTotalWithdrawals(currency, savingsAccountTransactions);
+
+        final HashMap<String, Money> map = updateRunningBalanceAndPivotDate(true, savingsAccountTransactions,
+                interestTotal,
+                overdraftInterestTotal, withHoldTaxTotal, currency);
+        interestTotal = map.get("interestTotal");
+        withHoldTaxTotal = map.get("withHoldTax");
+        overdraftInterestTotal = map.get("overdraftInterestTotal");
+        this.totalInterestPosted = interestTotal.getAmountDefaultedToNullIfZero();
+        this.totalOverdraftInterestDerived = overdraftInterestTotal.getAmountDefaultedToNullIfZero();
+        this.totalWithholdTax = withHoldTaxTotal.getAmountDefaultedToNullIfZero();
+
+        this.accountBalance = getRunningBalanceOnPivotDate();
+        this.accountBalance = Money.of(currency, this.accountBalance).plus(Money.of(currency, this.totalDeposits))
+                .plus(this.totalInterestPosted).minus(this.totalWithdrawals).minus(this.totalWithholdTax)
+                .minus(this.totalOverdraftInterestDerived).getAmount();
+    }
+
     @SuppressWarnings("unchecked")
     private HashMap<String, Money> updateRunningBalanceAndPivotDate(final boolean backdatedTxnsAllowedTill,
             final List<SavingsAccountTransaction> savingsAccountTransactions, Money interestTotal, Money overdraftInterestTotal,

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountDomainService.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountDomainService.java
@@ -56,4 +56,6 @@ public interface SavingsAccountDomainService {
             boolean backdatedTxnsAllowedTill);
 
     SavingsAccountTransaction handleHold(SavingsAccount account, BigDecimal amount, LocalDate transactionDate, Boolean lienAllowed);
+
+    SavingsAccount handleBalanceSanitisation(final SavingsAccount account);
 }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformService.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformService.java
@@ -127,5 +127,5 @@ public interface SavingsAccountWritePlatformService {
 
     CommandProcessingResult bulkGSIMClose(Long gsimId, JsonCommand command);
 
-    CommandProcessingResult satizeRunningBalances(Long savingsId);
+    CommandProcessingResult sanitizeRunningBalances(Long savingsId);
 }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformService.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformService.java
@@ -126,4 +126,6 @@ public interface SavingsAccountWritePlatformService {
     CommandProcessingResult gsimDeposit(Long gsimId, JsonCommand command);
 
     CommandProcessingResult bulkGSIMClose(Long gsimId, JsonCommand command);
+
+    CommandProcessingResult satizeRunningBalances(Long savingsId);
 }


### PR DESCRIPTION
This PR improves the unhold and hold transaction and also fixes balance calculation.


A new running balance sanitisation api loops through transactions to recalculate balances and edit transactions.
/api/v1/savingsaccounts/{account id}?command=sanitizeRunningBalances

Its a post API @Babs-ceviant and @olaolu