### PR TITLE
Update default Odoo base URL

### DIFF
--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -504,4 +504,4 @@ spring.data.redis.redis-template.bean-name=${FINERACT_REDIS_TEMPLATE_BEAN_NAME:r
 spring.data.redis.client-type=${FINERACT_REDIS_CLIENT_TYPE:lettuce}
 
 
-server.odoo.baseurl=${ODOO_BASE_URL:http:localhost:8069}
+server.odoo.baseurl=${ODOO_BASE_URL:https://odoo.uat.ceviant.co}


### PR DESCRIPTION
Change default server.odoo.baseurl in application.properties from http://localhost:8069 to https://odoo.uat.ceviant.co so the application points to the UAT Odoo instance by default. The value can still be overridden via the ODOO_BASE_URL environment variable.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
